### PR TITLE
Fixed parallel data loading for Moving MNIST

### DIFF
--- a/data/moving_mnist.lua
+++ b/data/moving_mnist.lua
@@ -147,7 +147,7 @@ function MovingMNISTDataset:plot()
   self:plotSeq(savedir .. '/seq.png')
 end
 
-trainLoader = MovingMNISTLoader(opt, 'train')
+trainLoader = MovingMNISTLoader(opt_t or opt, 'train')
 trainLoader:normalize()
-valLoader = MovingMNISTLoader(opt, 'val')
+valLoader = MovingMNISTLoader(opt_t or opt, 'val')
 valLoader:normalize()


### PR DESCRIPTION
Resolves issue #3 by using `opt_t` if `opt` is nil.